### PR TITLE
replace ReleaseOnlyWithLatest with PromptIfStale

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,9 +5,9 @@ license = Perl_5
 copyright_holder = L<DuckDuckGo, Inc.|https://duckduckgo.com/>
 copyright_year   = 2013
 
-[ReleaseOnlyWithLatest]
+[PromptIfStale]
 index = http://duckpan.org
-package = Dist::Zilla::Plugin::UploadToDuckPAN
+module = Dist::Zilla::Plugin::UploadToDuckPAN
 
 [UploadToDuckPAN]
 [@Basic]


### PR DESCRIPTION
`ReleaseOnlyWithLatest` was deprecated today which is causing Travis tests to fail, this fixes that. The chose package, `PromptIfStale` was suggested by Getty in the POD for `ReleaseOnlyWithLatest`.

//cc @jagtalon @russellholt 
